### PR TITLE
Streams

### DIFF
--- a/http-client-java/src/org/expath/httpclient/impl/BinaryResponseBody.java
+++ b/http-client-java/src/org/expath/httpclient/impl/BinaryResponseBody.java
@@ -48,8 +48,7 @@ public class BinaryResponseBody
     {
         myContentType = type;
         myHeaders = headers;
-        try {
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try(final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             byte[] buf = new byte[4096];
             int read = 0;
             while ( (read = in.read(buf)) > 0 ) {

--- a/http-client-java/src/org/expath/httpclient/impl/BinaryResponseBody.java
+++ b/http-client-java/src/org/expath/httpclient/impl/BinaryResponseBody.java
@@ -28,13 +28,6 @@ import org.expath.tools.ToolsException;
 public class BinaryResponseBody
         implements HttpResponseBody
 {
-    public BinaryResponseBody(Result result, byte[] value, ContentType type, HeaderSet headers)
-            throws HttpClientException
-    {
-        myContentType = type;
-        myHeaders = headers;
-        result.add(value);
-    }
 
     // TODO: Work only for binary response.  What if the response is encoded
     //   with base64?
@@ -48,18 +41,7 @@ public class BinaryResponseBody
     {
         myContentType = type;
         myHeaders = headers;
-        try(final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            byte[] buf = new byte[4096];
-            int read = 0;
-            while ( (read = in.read(buf)) > 0 ) {
-                out.write(buf, 0, read);
-            }
-            byte[] bytes = out.toByteArray();
-            result.add(bytes);
-        }
-        catch ( IOException ex ) {
-            throw new HttpClientException("error reading HTTP response", ex);
-        }
+        result.add(in);
     }
 
     @Override

--- a/http-client-java/src/org/expath/httpclient/impl/HrefRequestBody.java
+++ b/http-client-java/src/org/expath/httpclient/impl/HrefRequestBody.java
@@ -62,22 +62,17 @@ public class HrefRequestBody
     {
         try {
             String filename = new URI(myHref).getPath();
-            InputStream in = new FileInputStream(new File(filename));
-            byte[] buf = new byte[4096];
-            int l = -1;
-            while ( (l = in.read(buf)) != -1 ) {
-                out.write(buf, 0, l);
+            try (final InputStream in = new FileInputStream(new File(filename))) {
+                byte[] buf = new byte[4096];
+                int l = -1;
+                while ((l = in.read(buf)) != -1) {
+                    out.write(buf, 0, l);
+                }
+            } catch (IOException ex) {
+                throw new HttpClientException("Error sending the file content", ex);
             }
-            in.close();
-        }
-        catch ( URISyntaxException ex ) {
+        } catch ( URISyntaxException ex ) {
             throw new HttpClientException("Bad URI: " + myHref, ex);
-        }
-        catch ( FileNotFoundException ex ) {
-            throw new HttpClientException("Error sending the file content", ex);
-        }
-        catch ( IOException ex ) {
-            throw new HttpClientException("Error sending the file content", ex);
         }
     }
 

--- a/http-client-java/src/org/expath/httpclient/impl/TextResponseBody.java
+++ b/http-client-java/src/org/expath/httpclient/impl/TextResponseBody.java
@@ -9,12 +9,10 @@
 
 package org.expath.httpclient.impl;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import org.expath.httpclient.ContentType;
 import org.expath.httpclient.HeaderSet;
 import org.expath.httpclient.HttpClientException;
@@ -34,45 +32,20 @@ public class TextResponseBody
     public TextResponseBody(Result result, InputStream in, ContentType type, HeaderSet headers)
             throws HttpClientException
     {
-        // FIXME: ...
-        String charset = "utf-8";
-        try {
-            Reader reader = new InputStreamReader(in, charset);
-            init(result, reader, type, headers);
-        }
-        catch ( UnsupportedEncodingException ex ) {
-            String msg = "not supported charset reading HTTP response: " + charset;
-            throw new HttpClientException(msg, ex);
-        }
+        myContentType = type;
+        myHeaders = headers;
+        // TODO: ...
+        final Charset charset = StandardCharsets.UTF_8;
+        final Reader reader = new InputStreamReader(in, charset);
+        result.add(reader);
     }
 
     public TextResponseBody(Result result, Reader in, ContentType type, HeaderSet headers)
             throws HttpClientException
     {
-        init(result, in, type, headers);
-    }
-
-    private void init(Result result, Reader in, ContentType type, HeaderSet headers)
-            throws HttpClientException
-    {
         myContentType = type;
         myHeaders = headers;
-        // BufferedReader handles the ends of line (all \n, \r, and \r\n are
-        // transformed to \n)
-        try {
-            StringBuilder builder = new StringBuilder();
-            BufferedReader buf_in = new BufferedReader(in);
-            String buf = null;
-            while ( (buf = buf_in.readLine()) != null ) {
-                builder.append(buf);
-                builder.append('\n');
-            }
-            String value = builder.toString();
-            result.add(value);
-        }
-        catch ( IOException ex ) {
-            throw new HttpClientException("error reading HTTP response", ex);
-        }
+        result.add(in);
     }
 
     @Override

--- a/http-client-java/src/org/expath/httpclient/impl/XmlResponseBody.java
+++ b/http-client-java/src/org/expath/httpclient/impl/XmlResponseBody.java
@@ -13,6 +13,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import javax.xml.transform.Source;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamSource;
@@ -39,15 +41,9 @@ public class XmlResponseBody
             throws HttpClientException
     {
         // TODO: ...
-        String charset = "utf-8";
-        try {
-            Reader reader = new InputStreamReader(in, charset);
-            init(result, reader, type, headers, html);
-        }
-        catch ( UnsupportedEncodingException ex ) {
-            String msg = "not supported charset reading HTTP response: " + charset;
-            throw new HttpClientException(msg, ex);
-        }
+        final Charset charset = StandardCharsets.UTF_8;
+        final Reader reader = new InputStreamReader(in, charset);
+        init(result, reader, type, headers, html);
     }
 
     public XmlResponseBody(Result result, Reader in, ContentType type, HeaderSet headers, boolean html)
@@ -56,7 +52,7 @@ public class XmlResponseBody
         init(result, in, type, headers, html);
     }
 
-    private void init(Result result, Reader in, ContentType type, HeaderSet headers, boolean html)
+    private void init(final Result result, final Reader in, final ContentType type, final HeaderSet headers, final boolean html)
             throws HttpClientException
     {
         myContentType = type;
@@ -71,13 +67,12 @@ public class XmlResponseBody
                 InputSource input = new InputSource(in);
                 src = new SAXSource(parser, input);
                 src.setSystemId(sys_id);
-            }
-            else {
+            } else {
                 src = new StreamSource(in, sys_id);
             }
             result.add(src);
         }
-        catch ( SAXException ex ) {
+        catch (SAXException ex) {
             throw new HttpClientException("error parsing result HTML", ex);
         }
     }

--- a/http-client-java/src/org/expath/httpclient/model/Result.java
+++ b/http-client-java/src/org/expath/httpclient/model/Result.java
@@ -9,6 +9,8 @@
 
 package org.expath.httpclient.model;
 
+import java.io.Reader;
+import java.io.InputStream;
 import javax.xml.transform.Source;
 import org.expath.httpclient.HttpClientException;
 import org.expath.httpclient.HttpResponse;
@@ -63,22 +65,22 @@ public interface Result
             throws HttpClientException;
 
     /**
-     * Add an {@code xs:string} to the result sequence.
+     * Add a string value to the result sequence.
      * 
      * @param string The string to add to the result sequence.
      * @throws HttpClientException If any error occurs.
      */
-    public void add(String string)
+    public void add(Reader string)
             throws HttpClientException;
 
     /**
-     * Add an {@code xs:base64Binary} to the result sequence.
+     * Add raw binary to the result sequence.
      * 
-     * @param bytes The bytes representing the base64 binary item to add to the
+     * @param bytes The bytes representing the binary item to add to the
      *      result sequence.
      * @throws HttpClientException If any error occurs.
      */
-    public void add(byte[] bytes)
+    public void add(InputStream bytes)
             throws HttpClientException;
 
     /**
@@ -124,5 +126,5 @@ public interface Result
 /*                                                                          */
 /*  The Initial Developer of the Original Code is Florent Georges.          */
 /*                                                                          */
-/*  Contributor(s): none.                                                   */
+/*  Contributor(s): Adam Retter                                             */
 /* ------------------------------------------------------------------------ */


### PR DESCRIPTION
The EXPath http-client-java should not read the response bodies into memory. When you are working with requests for large documents or binary files this will very quickly exhaust the available system memory.

This very simple change makes the caller responsible for deciding what to do with the response body data. Enabling implementations (such as eXist) which can efficiently send the stream to the client to perform IO in a streaming manner and thus drastically reduce memory overhead.
